### PR TITLE
[WF-226] add on-demand UAT workflow

### DIFF
--- a/.github/workflows/uats.yaml
+++ b/.github/workflows/uats.yaml
@@ -2,6 +2,23 @@ name: UAT tests
 
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      track:
+        description: 'Charm channel track'
+        required: false
+        default: '1.23'
+        type: string
+      risk:
+        description: 'Charm channel risk to test against'
+        required: true
+        default: 'edge'
+        type: choice
+        options:
+          - edge
+          - beta
+          - candidate
+          - stable
 
 jobs:
   uats:
@@ -17,7 +34,7 @@ jobs:
       fail-fast: false
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.uat }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
     steps:
       - name: Maximize GH runner disk
@@ -59,7 +76,7 @@ jobs:
           sudo snap start docker
 
       - name: Deploy Temporal models
-        run: just deploy-temporal
+        run: just deploy-temporal ${{ inputs.track || '1.23' }} ${{ inputs.risk || 'edge' }}
 
       - name: Execute UATs
         run: just ${{ matrix.uat }}

--- a/.github/workflows/uats.yaml
+++ b/.github/workflows/uats.yaml
@@ -4,11 +4,20 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-      track:
-        description: 'Charm channel track'
+      server-track:
+        description: 'Server-side charm channel track'
         required: false
         default: '1.23'
-        type: string
+        type: choice
+        options:
+          - '1.23'
+      worker-track:
+        description: 'Worker charm channel track'
+        required: false
+        default: '1.0'
+        type: choice
+        options:
+          - '1.0'
       risk:
         description: 'Charm channel risk to test against'
         required: true
@@ -76,7 +85,7 @@ jobs:
           sudo snap start docker
 
       - name: Deploy Temporal models
-        run: just deploy-temporal ${{ inputs.track || '1.23' }} ${{ inputs.risk || 'edge' }}
+        run: just deploy-temporal ${{ inputs.server-track || '1.23' }} ${{ inputs.worker-track || '1.0' }} ${{ inputs.risk || 'edge' }}
 
       - name: Execute UATs
         run: just ${{ matrix.uat }}

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ sudo k8s set load-balancer.l2-mode=true load-balancer.cdrs=10.2.0.0/24
 sudo k8s enable ingress load-balancer
 sudo k8s kubectl config view --raw > ~/.kube/config
 just install-nginx-controller
-just deploy-temporal [track] [risk]
+just deploy-temporal [track] [worker_track] [risk]
 just uats-{namespace-isolation,ingress,cos}
 ```
 
-The `track` and `risk` arguments are optional and default to `1.23` and `edge` respectively. For example, to test against `1.23/beta`:
+The `track`, `worker_track`, and `risk` arguments are optional and default to `1.23`, `1.0`, and `edge` respectively. For example, to test against `1.23/beta`:
 
 ```bash
-just deploy-temporal 1.23 beta
+just deploy-temporal 1.23 1.0 beta
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ For each UAT, we use `goss` to implement pre-flight checks before UATs are execu
 
 ## Executing UATs
 
-Starting from a fresh environment:
+### On demand via CI (recommended)
+
+UATs can be triggered manually from the GitHub Actions UI against a specific Charmhub channel risk. (e.g. `edge` → `beta` → `candidate` → `stable`).
+
+The workflow will deploy a fresh Temporal stack using the specified channel (e.g. `1.23/candidate`) and run all UAT categories.
+
+### Locally (fresh environment)
 
 ```bash
 sudo -E concierge prepare -p k8s --extra-snaps=astral-uv
@@ -42,6 +48,12 @@ sudo k8s set load-balancer.l2-mode=true load-balancer.cdrs=10.2.0.0/24
 sudo k8s enable ingress load-balancer
 sudo k8s kubectl config view --raw > ~/.kube/config
 just install-nginx-controller
-just deploy-temporal
+just deploy-temporal [track] [risk]
 just uats-{namespace-isolation,ingress,cos}
+```
+
+The `track` and `risk` arguments are optional and default to `1.23` and `edge` respectively. For example, to test against `1.23/beta`:
+
+```bash
+just deploy-temporal 1.23 beta
 ```

--- a/justfile
+++ b/justfile
@@ -219,7 +219,7 @@ format:
     tox -e format
 
 # Deploy the Temporal applications for UATs
-deploy-temporal temporal_track="1.23" temporal_risk="edge":
+deploy-temporal temporal_track="1.23" temporal_worker_track="1.0" temporal_risk="edge":
     #!/usr/bin/bash
     set -euxo pipefail
 
@@ -239,7 +239,7 @@ deploy-temporal temporal_track="1.23" temporal_risk="edge":
 
     just deploy-temporal-server ${suffix} "${temporal_track}/${temporal_risk}"
     just deploy-cos ${suffix}
-    just deploy-workers localhost:5000/worker-python:dev localhost:5000/worker-go:dev ${suffix} "1.0/${temporal_risk}"
+    just deploy-workers localhost:5000/worker-python:dev localhost:5000/worker-go:dev ${suffix} "${temporal_worker_track}/${temporal_risk}"
 
     just integrate-applications ${suffix}
 

--- a/justfile
+++ b/justfile
@@ -125,7 +125,6 @@ deploy-cos model_suffix="fixed" cos_channel="latest/stable":
     juju offer cos-uats-${model_suffix}.prometheus:metrics-endpoint
     # TODO: add tracing
 
-# TODO: change 1.0/edge -> 1.0/stable
 [private]
 deploy-workers worker_python_image worker_go_image model_suffix="fixed" worker_channel="1.0/edge":
     #!/usr/bin/bash
@@ -218,7 +217,7 @@ format:
     tox -e format
 
 # Deploy the Temporal applications for UATs
-deploy-temporal:
+deploy-temporal temporal_track="1.23" temporal_risk="edge":
     #!/usr/bin/bash
     set -euxo pipefail
 
@@ -236,9 +235,9 @@ deploy-temporal:
 
     just create-models ${suffix}
 
-    just deploy-temporal-server ${suffix}
+    just deploy-temporal-server ${suffix} "${temporal_track}/${temporal_risk}"
     just deploy-cos ${suffix}
-    just deploy-workers localhost:5000/worker-python:dev localhost:5000/worker-go:dev ${suffix}
+    just deploy-workers localhost:5000/worker-python:dev localhost:5000/worker-go:dev ${suffix} "1.0/${temporal_risk}"
 
     just integrate-applications ${suffix}
 

--- a/justfile
+++ b/justfile
@@ -186,12 +186,14 @@ integrate-applications model_suffix="fixed":
 [private]
 create-namespaces:
     #!/usr/bin/bash
+    set -euxo pipefail
+
     juju switch "temporal-server-uats-$(just get-model-suffix)"
 
     juju wait-for application temporal-admin-k8s --query='name == "temporal-admin-k8s" && status == "active"'
 
-    juju run temporal-admin-k8s/0 cli args="operator namespace create --namespace worker-go-namespace --retention 3d" --wait 1m
-    juju run temporal-admin-k8s/0 cli args="operator namespace create --namespace worker-python-namespace --retention 3d" --wait 1m
+    juju run temporal-admin-k8s/0 cli args="operator namespace create --namespace worker-go-namespace --retention 3d" --wait 2m
+    juju run temporal-admin-k8s/0 cli args="operator namespace create --namespace worker-python-namespace --retention 3d" --wait 2m
 
 # Pack the python worker image
 pack-worker-python debug="":


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Adds a workflow_dispatch trigger to the UAT workflow, enabling UATs on demand against a chosen Charmhub channel risk (edge, beta, candidate, stable) and track (default 1.23). 

Changes:
- The justfile's deploy-temporal is updated to accept `temporal_track` and `temporal_risk` parameters
- `cancel-in-progress` is now conditional: `true` for PR runs (existing behaviour), `false` for `workflow_dispatch` runs 

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
## Closes #16 

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

Added `set -euxo pipefail` to `create-namespaces` to ensure a failed namespace creation halts execution immediately rather than silently continuing, and increased the `juju run` timeout from `1m` to `2m` to reduce the chance of transient timeouts.


---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
