### PR TITLE
[WF-218] use custom concierge config for uats

### DIFF
--- a/.github/workflows/custom-concierge.yaml
+++ b/.github/workflows/custom-concierge.yaml
@@ -1,0 +1,39 @@
+juju:
+  model-defaults:
+    test-mode: "true"
+    automatically-retry-hooks: "false"
+
+providers:
+  lxd:
+    enable: true
+  k8s:
+    enable: true
+    bootstrap: true
+    bootstrap-constraints:
+      root-disk: "2G"
+    features:
+      load-balancer:
+        l2-mode: "true"
+        cidrs: "10.2.0.0/24"
+      local-storage: {}
+      network: {}
+      ingress: {}
+
+host:
+  packages:
+    - gnome-keyring
+    - python3-pip
+    - python3-venv
+  snaps:
+    just:
+      channel: latest/stable
+    astral-uv:
+      channel: latest/stable
+    charmcraft:
+      channel: latest/stable
+    rockcraft:
+      channel: latest/stable
+    jq:
+      channel: latest/stable
+    yq:
+      channel: latest/stable

--- a/.github/workflows/uats.yaml
+++ b/.github/workflows/uats.yaml
@@ -65,18 +65,10 @@ jobs:
           sudo rm -r /run/containerd
 
           sudo snap install concierge --classic
-
-          sudo snap install just --classic
-
-          sudo -E concierge prepare -p k8s --extra-snaps=astral-uv
-
-          sudo k8s set load-balancer.l2-mode=true load-balancer.cidrs=10.2.0.0/24
-          sudo k8s enable ingress load-balancer
-
+          sudo -E concierge prepare -c .github/workflows/custom-concierge.yaml
+          sudo k8s enable ingress
           sudo k8s kubectl config view --raw > ~/.kube/config
-
           uv tool install tox
-
           just install-nginx-controller
 
       - name: Install docker (after k8s bootstrapped)

--- a/justfile
+++ b/justfile
@@ -156,6 +156,8 @@ integrate-applications model_suffix="fixed":
     juju integrate temporal-k8s:admin temporal-admin-k8s:admin
 
     juju integrate temporal-k8s:ui temporal-ui-k8s:ui
+    juju integrate temporal-k8s:temporal-host-info temporal-admin-k8s:temporal-host-info
+    juju integrate temporal-k8s:temporal-host-info temporal-ui-k8s:temporal-host-info
 
     juju integrate temporal-ui-ingress:certificates self-signed-certificates:certificates
 
@@ -189,9 +191,8 @@ create-namespaces:
     set -euxo pipefail
 
     juju switch "temporal-server-uats-$(just get-model-suffix)"
-
+    juju wait-for application temporal-k8s --query='name == "temporal-k8s" && status == "active"'
     juju wait-for application temporal-admin-k8s --query='name == "temporal-admin-k8s" && status == "active"'
-
     juju run temporal-admin-k8s/0 cli args="operator namespace create --namespace worker-go-namespace --retention 3d" --wait 2m
     juju run temporal-admin-k8s/0 cli args="operator namespace create --namespace worker-python-namespace --retention 3d" --wait 2m
 


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
This PR replaces the upstream `k8s` environment preset in our UAT workflow with a declarative `custom-concierge.yaml` configuration file.
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
Closed #13 
---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->

Wiped previous environment states and initialized the preparation phase manually:
   ```bash
   sudo -E concierge prepare -c ./custom-concierge.yaml
  ```
---

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated